### PR TITLE
Remove buy and offer features

### DIFF
--- a/components/molecules/ProductActions.tsx
+++ b/components/molecules/ProductActions.tsx
@@ -1,14 +1,12 @@
 'use client';
 
 import { forwardRef } from 'react';
-import { MessageCircle, ShoppingCart, HandCoins } from 'lucide-react';
+import { MessageCircle } from 'lucide-react';
 import cn from '@/lib/utils';
 import { Button } from '@/components/atoms/Button/Button';
 
 export interface ProductActionsProps extends React.HTMLAttributes<HTMLDivElement> {
   onMessageSeller?: () => void;
-  onBuyNow?: () => void;
-  onMakeOffer?: () => void;
   sellerId: string;
   productId: string;
 }
@@ -18,8 +16,6 @@ const ProductActions = forwardRef<HTMLDivElement, ProductActionsProps>(
     {
       className,
       onMessageSeller,
-      onBuyNow,
-      onMakeOffer,
       sellerId,
       productId,
       ...props
@@ -35,51 +31,11 @@ const ProductActions = forwardRef<HTMLDivElement, ProductActionsProps>(
       }
     };
 
-    const handleBuyNow = () => {
-      if (onBuyNow) {
-        onBuyNow();
-      } else {
-        console.log(`Buy now product ${productId}`);
-        // TODO: Implement checkout flow
-      }
-    };
-
-    const handleMakeOffer = () => {
-      if (onMakeOffer) {
-        onMakeOffer();
-      } else {
-        console.log(`Make offer for product ${productId}`);
-        // TODO: Implement offer modal
-      }
-    };
-
     return (
       <div ref={ref} className={cn('space-y-3', className)} {...props}>
-        {/* Primary Actions */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <Button
-            variant="primary"
-            size="default"
-            onClick={handleBuyNow}
-            className="w-full text-base py-3"
-          >
-            <ShoppingCart className="mr-2 h-5 w-5" />
-            Buy Now
-          </Button>
-          <Button
-            variant="secondary"
-            size="default"
-            onClick={handleMakeOffer}
-            className="w-full text-base py-3"
-          >
-            <HandCoins className="mr-2 h-5 w-5" />
-            Make Offer
-          </Button>
-        </div>
-
         {/* Message Seller Button */}
         <Button
-          variant="secondary"
+          variant="primary"
           size="default"
           onClick={handleMessageSeller}
           className="w-full text-base py-3"


### PR DESCRIPTION
- Removed "Buy Now" and "Make Offer" buttons from ProductActions component
- Kept only "Message Seller" button since buying/offering will be handled through user messages
- Cleaned up unused imports (ShoppingCart, HandCoins icons)
- Simplified component props to only support messaging functionality