### PR TITLE
Implement frontend password reset functionality

### DIFF
--- a/components/organisms/AuthPage/PasswordReset.tsx
+++ b/components/organisms/AuthPage/PasswordReset.tsx
@@ -1,28 +1,31 @@
 "use client";
 
-import { useMutation } from "@tanstack/react-query";
+import { useState, useTransition } from "react";
 import { PasswordResetRequest, PasswordResetRequestData } from "@/components/molecules/AuthForm/PasswordResetRequest";
 import { Container } from "@/components/atoms/Container/Container";
-
-// TODO: Replace with actual API call
-const requestPasswordReset = async (data: PasswordResetRequestData): Promise<void> => {
-  console.log("Password reset request for:", data.email);
-  // Simulate API call
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-};
+import { requestPasswordResetAction } from "@/lib/auth/actions";
 
 export function PasswordReset() {
-  const resetMutation = useMutation({
-    mutationFn: requestPasswordReset,
-  });
+  const [isPending, startTransition] = useTransition();
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
 
   const handleSubmit = (data: PasswordResetRequestData) => {
-    resetMutation.mutate(data);
+    setError(undefined);
+    setSuccess(false);
+
+    startTransition(async () => {
+      const result = await requestPasswordResetAction({ email: data.email });
+
+      if (result.success) {
+        setSuccess(true);
+      } else {
+        setError(result.error || "Greška pri slanju email-a. Molimo pokušajte ponovo.");
+      }
+    });
   };
 
-  const loading = resetMutation.isPending;
-  const success = resetMutation.isSuccess;
-  const error = resetMutation.error ? "Greška pri slanju email-a. Molimo pokušajte ponovo." : undefined;
+  const loading = isPending;
 
   return (
     <Container className="min-h-screen flex items-center justify-center py-8">

--- a/components/organisms/AuthPage/PasswordResetForm.tsx
+++ b/components/organisms/AuthPage/PasswordResetForm.tsx
@@ -1,39 +1,43 @@
 "use client";
 
+import { useState, useTransition } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { useMutation } from "@tanstack/react-query";
 import { PasswordResetConfirm, PasswordResetConfirmData } from "@/components/molecules/AuthForm/PasswordResetConfirm";
 import { Container } from "@/components/atoms/Container/Container";
-
-// TODO: Replace with actual API call
-const confirmPasswordReset = async (data: PasswordResetConfirmData & { token: string }): Promise<void> => {
-  console.log("Password reset data:", data);
-  // Simulate API call
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-};
+import { resetPasswordAction } from "@/lib/auth/actions";
 
 export function PasswordResetForm() {
   const router = useRouter();
   const params = useParams();
   const token = params.token as string;
 
-  const resetConfirmMutation = useMutation({
-    mutationFn: confirmPasswordReset,
-    onSuccess: () => {
-      // Redirect to login after success
-      setTimeout(() => {
-        router.push("/login");
-      }, 2000);
-    },
-  });
+  const [isPending, startTransition] = useTransition();
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
 
   const handleSubmit = (data: PasswordResetConfirmData & { token: string }) => {
-    resetConfirmMutation.mutate(data);
+    setError(undefined);
+    setSuccess(false);
+
+    startTransition(async () => {
+      const result = await resetPasswordAction({
+        token: data.token,
+        newPassword: data.password,
+      });
+
+      if (result.success) {
+        setSuccess(true);
+        // Redirect to login after success
+        setTimeout(() => {
+          router.push("/login");
+        }, 2000);
+      } else {
+        setError(result.error || "Greška pri promeni lozinke. Link možda nije važeći ili je istekao.");
+      }
+    });
   };
 
-  const loading = resetConfirmMutation.isPending;
-  const success = resetConfirmMutation.isSuccess;
-  const error = resetConfirmMutation.error ? "Greška pri promeni lozinke. Link možda nije važeći ili je istekao." : undefined;
+  const loading = isPending;
 
   return (
     <Container className="min-h-screen flex items-center justify-center py-8">

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -67,6 +67,23 @@ export interface ChangePasswordRequest {
   newPassword: string;
 }
 
+export interface RequestPasswordResetRequest {
+  email: string;
+}
+
+export interface RequestPasswordResetResponse {
+  message: string;
+}
+
+export interface ResetPasswordRequest {
+  token: string;
+  newPassword: string;
+}
+
+export interface ResetPasswordResponse {
+  message: string;
+}
+
 export interface UserProfileResponse {
   user: ApiUser;
   stats: {

--- a/lib/auth/actions.ts
+++ b/lib/auth/actions.ts
@@ -7,9 +7,17 @@
 "use server";
 
 import { setAuthTokens, removeAuthTokens, getAccessToken } from "./cookies";
-import type { RegisterRequest, LoginRequest, AuthResponse } from "../api/types";
+import type {
+  RegisterRequest,
+  LoginRequest,
+  AuthResponse,
+  RequestPasswordResetRequest,
+  RequestPasswordResetResponse,
+  ResetPasswordRequest,
+  ResetPasswordResponse
+} from "../api/types";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api";
 
 /**
  * Register a new user
@@ -215,6 +223,76 @@ export async function facebookAuthAction(
         result.refreshToken
       );
     }
+
+    return { success: true, data: result };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+}
+
+/**
+ * Request password reset
+ * Sends an email with a reset token if the email exists
+ */
+export async function requestPasswordResetAction(
+  data: RequestPasswordResetRequest
+): Promise<{ success: boolean; data?: RequestPasswordResetResponse; error?: string }> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/auth/request-password-reset`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return {
+        success: false,
+        error: errorData.error || "Failed to request password reset",
+      };
+    }
+
+    const result: RequestPasswordResetResponse = await response.json();
+
+    return { success: true, data: result };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+}
+
+/**
+ * Reset password with token
+ * Sets a new password using the reset token from email
+ */
+export async function resetPasswordAction(
+  data: ResetPasswordRequest
+): Promise<{ success: boolean; data?: ResetPasswordResponse; error?: string }> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/auth/reset-password`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return {
+        success: false,
+        error: errorData.error || "Failed to reset password",
+      };
+    }
+
+    const result: ResetPasswordResponse = await response.json();
 
     return { success: true, data: result };
   } catch (error) {


### PR DESCRIPTION
- Add password reset TypeScript types (RequestPasswordResetRequest, ResetPasswordRequest, etc.)
- Create server actions for password reset flow:
  - requestPasswordResetAction: sends reset email
  - resetPasswordAction: resets password with token
- Update PasswordReset organism to call request-password-reset API
- Update PasswordResetForm organism to call reset-password API
- Fix API_BASE_URL default to include /api path
- Replace React Query with useTransition for server actions
- Maintain redirect to login after successful password reset

Integrates with backend endpoints:
- POST /api/auth/request-password-reset
- POST /api/auth/reset-password